### PR TITLE
Logging through python logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # dependencies
 /frontendServer/node_modules
 /styleguideServer/node_modules
+/ReactApp/node_modules
 /node_modules
 /.pnp
 .pnp.js
@@ -74,16 +75,16 @@ yarn-error.log*
 *.cer
 *.key
 
-epics/testIOC/configure/O.linux-x86_64/
+epics/testIOC/configure/O.*/
 epics/testIOC/iocBoot/iocexample/envPaths
 epics/testIOC/iocBoot/ioctestIOC/envPaths
 epics/testIOC/dbd/testIOC.dbd
-epics/testIOC/testIOCApp/Db/O.linux-x86_64/
-epics/testIOC/testIOCApp/src/O.Common/
-epics/testIOC/testIOCApp/src/O.linux-x86_64/
+epics/testIOC/testIOCApp/Db/O.*/
+epics/testIOC/testIOCApp/src/O.*/
 epics/testIOC/bin/
 epics/testIOC/bin/
 epics/*.gz
+epics/*.local
 
 __pycache__/
 

--- a/pvServer/log.py
+++ b/pvServer/log.py
@@ -1,0 +1,43 @@
+import os
+import logging
+
+# Logging facilities
+#
+initial_log_level = os.environ.get('REACT_APP_LogLevel', 'INFO')
+if not hasattr(logging, initial_log_level.upper()):
+    print('Log level {} not found. Use ERROR, WARNING, INFO, or DEBUG.'.format(initial_log_level))
+    exit()
+log_file = os.environ.get('REACT_APP_LogFile', None)
+
+logging.basicConfig(format='%(asctime)s %(levelname)-7s %(message)s', filename=log_file)
+
+logging.getLogger('werkzeug').setLevel(logging.ERROR)
+
+logger = logging.getLogger('pvServer')
+logger.setLevel(getattr(logging, initial_log_level.upper()))
+
+# Logging optimization
+# Prevent formatting a message if logging is not enabled at given level.
+# Use command an environmental variable REACT_APP_LogLevel to set the logging level.
+#
+def _log(func, msg, args, kwargs):
+    if isinstance(msg, str):
+        func(msg.format(*args), **kwargs)
+    else:
+        func(str(msg), *args, **kwargs)
+
+def debug(msg, *args, **kwagrs):
+    if logger.isEnabledFor(logging.DEBUG):
+        _log(logger.debug, msg, args, kwagrs)
+
+def info(msg, *args, **kwagrs):
+    if logger.isEnabledFor(logging.INFO):
+        _log(logger.info, msg, args, kwagrs)
+
+def warning(msg, *args, **kwagrs):
+    if logger.isEnabledFor(logging.WARNING):
+        _log(logger.warning, msg, args, kwagrs)
+
+def error(msg, *args, **kwagrs):
+    if logger.isEnabledFor(logging.ERROR):
+        _log(logger.error, msg, args, kwagrs)

--- a/pvServer/log.py
+++ b/pvServer/log.py
@@ -4,6 +4,8 @@ import logging
 import logging.handlers
 
 def _convert_to_int(value, min_value, default_value):
+    if value is None:
+        return default_value
     try:
         return max(min_value, int(value))
     except ValueError:

--- a/pvServer/log.py
+++ b/pvServer/log.py
@@ -1,30 +1,71 @@
 import os
+import queue
 import logging
+import logging.handlers
+
+def _convert_to_int(value, min_value, default_value):
+    try:
+        return max(min_value, int(value))
+    except ValueError:
+        return default_value
 
 # Logging facilities
+#
+# Use queues to avoid delays in the main thread.
 #
 initial_log_level = os.environ.get('REACT_APP_LogLevel', 'INFO')
 if not hasattr(logging, initial_log_level.upper()):
     print('Log level {} not found. Use ERROR, WARNING, INFO, or DEBUG.'.format(initial_log_level))
     exit()
 log_file = os.environ.get('REACT_APP_LogFile', None)
+if log_file is not None:
+    log_file = os.path.abspath(log_file)
+log_file_max_size = _convert_to_int(os.environ.get('REACT_APP_LogFileSize', None), 1024, 16 * 1024 * 1024) # 16 MB
+log_file_backup = _convert_to_int(os.environ.get('REACT_APP_LogFileBackup', None), 0, 2)
 
-logging.basicConfig(format='%(asctime)s %(levelname)-7s %(message)s', filename=log_file)
+print('pvServer Logging:')
+print('')
+print(f'Log level: { initial_log_level }')
+if log_file is not None:
+    print(f'Log output: { log_file }')
+    print(f'Log max size: { log_file_max_size } bytes')
+    print(f'Log file backup: { log_file_backup }')
+else:
+    print(f'Log output: stdout')
+print('')
+
+log_queue = queue.Queue(512)
+queue_handler = logging.handlers.QueueHandler(log_queue)
+if log_file is None:
+    log_handler = logging.StreamHandler()
+else:
+    log_handler = logging.handlers.RotatingFileHandler(log_file, maxBytes=log_file_max_size, backupCount=log_file_backup)
+queue_listener = logging.handlers.QueueListener(log_queue, log_handler)
+log_handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)-7s %(message)s'))
+
+queue_listener.start()
+
+# Let us collect logs from all loggers.
+logging.getLogger('').addHandler(log_handler)
 
 logging.getLogger('werkzeug').setLevel(logging.ERROR)
 
 logger = logging.getLogger('pvServer')
 logger.setLevel(getattr(logging, initial_log_level.upper()))
 
+
 # Logging optimization
 # Prevent formatting a message if logging is not enabled at given level.
 # Use command an environmental variable REACT_APP_LogLevel to set the logging level.
 #
 def _log(func, msg, args, kwargs):
-    if isinstance(msg, str):
-        func(msg.format(*args), **kwargs)
-    else:
-        func(str(msg), *args, **kwargs)
+    try:
+        if isinstance(msg, str):
+            func(msg.format(*args), **kwargs)
+        else:
+            func(str(msg), *args, **kwargs)
+    except queue.Full:
+        print(f'Log queue full. Ignoring log [{ msg }].')
 
 def debug(msg, *args, **kwagrs):
     if logger.isEnabledFor(logging.DEBUG):

--- a/pvServer/log.py
+++ b/pvServer/log.py
@@ -41,3 +41,7 @@ def warning(msg, *args, **kwagrs):
 def error(msg, *args, **kwagrs):
     if logger.isEnabledFor(logging.ERROR):
         _log(logger.error, msg, args, kwagrs)
+
+def exception(msg, *args, **kwargs):
+    if logger.isEnabledFor(logging.CRITICAL):
+        _log(logger.exception, msg, args, kwargs)

--- a/pvServer/pvServer.py
+++ b/pvServer/pvServer.py
@@ -43,6 +43,8 @@ print('REACT_APP_PyEpicsServerNamespace: '+ str(os.environ['REACT_APP_PyEpicsSer
 print('REACT_APP_EnableLogin: '+ str(os.environ['REACT_APP_EnableLogin']))
 print('REACT_APP_LogLevel: {}'.format(os.environ.get('REACT_APP_LogLevel', None)))
 print('REACT_APP_LogFile: {}'.format(os.environ.get('REACT_APP_LogFile', None)))
+print('REACT_APP_LogFileSize: {}'.format(os.environ.get('REACT_APP_LogFileSize', None)))
+print('REACT_APP_LogFileBackup: {}'.format(os.environ.get('REACT_APP_LogFileBackup', None)))
 
 
 print("")

--- a/pvServer/pvServer.py
+++ b/pvServer/pvServer.py
@@ -82,7 +82,7 @@ def check_pv_initialized_after_disconnect():
         for pvname in list(clientPVlist) :
             if not((len(clientPVlist[pvname]['sockets'])>0 ) or (len(clientPVlist[pvname]['socketsRW'])>0 )or (len(clientPVlist[pvname]['socketsRO'])>0 )):
                 #print(pvname, " has no listening clients, removing")
-                
+
                 clientPVlist[pvname]['pv'].disconnect()
                 clientPVlist.pop(pvname)
             else:
@@ -153,17 +153,17 @@ def check_pv_initialized_after_disconnect():
         #                 socketio.emit(eventName,d,str(dbURL)+'rw',namespace='/pvServer')
         #                 d={'dbURL': dbURL,'write_access':False,'data': data}
         #                 socketio.emit(eventName,d,str(dbURL)+'ro',namespace='/pvServer')
-                        
+
         #             except:
         #                 print("Unexpected error:", sys.exc_info()[0])
-        #                 raise    
+        #                 raise
         time.sleep(0.1)
 def dbWatchControlThread():
     global clientDbWatchList
 
     #print("dbWatchControlThread started")
     while (True):
-        
+
         for watchEventName in list(clientDbWatchList) :
             #print("clientDbWatchList[watchEventName]['sockets']",clientDbWatchList[watchEventName]['sockets'])
             if clientDbWatchList[watchEventName]['threadStarted'] is False:
@@ -172,10 +172,10 @@ def dbWatchControlThread():
                 clientDbWatchList[watchEventName]['closeWatch']=False
                 #print("control thread starting thread",watchEventName)
             if len(clientDbWatchList[watchEventName]['sockets'])==0:
-               
+
                 if clientDbWatchList[watchEventName]['closeWatch']==False:
                     #print("before client close")
-                    
+
                     clientDbWatchList[watchEventName]['closeWatch']=True
                     #print("after client close")
             if clientDbWatchList[watchEventName]['threadClosed'] is True:
@@ -197,10 +197,10 @@ def dbWatchControlThread():
             #             socketio.emit(eventName,d,str(dbURL)+'rw',namespace='/pvServer')
             #             d={'dbURL': dbURL,'write_access':False,'data': data}
             #             socketio.emit(eventName,d,str(dbURL)+'ro',namespace='/pvServer')
-                        
+
             #         except:
             #             print("Unexpected error:", sys.exc_info()[0])
-            #             raise    
+            #             raise
         time.sleep(0.1)
 
 def dbWatchThread(watchEventName):
@@ -209,9 +209,9 @@ def dbWatchThread(watchEventName):
     #print("dbWatchThread started for:",watchEventName)
     exitThread=False
     while (exitThread==False):
-        
+
         if watchEventName in clientDbWatchList :
-            
+
             with clientDbWatchList[watchEventName]['watch'] as stream:
                 #for change in stream:
                 while stream.alive:
@@ -230,18 +230,18 @@ def dbWatchThread(watchEventName):
                             socketio.emit(eventName,d,str(dbURL)+'rw',namespace='/pvServer')
                             d={'dbURL': dbURL,'write_access':False,'data': data}
                             socketio.emit(eventName,d,str(dbURL)+'ro',namespace='/pvServer')
-                            
+
                         except:
                             print("Unexpected error:", sys.exc_info()[0])
-                            raise 
+                            raise
                     #print("dbWatchThread running:",watchEventName)
                     if clientDbWatchList[watchEventName]['closeWatch']==True:
-                        #print("clientDbWatchList[watchEventName]['closeWatch']",clientDbWatchList[watchEventName]['closeWatch']) 
+                        #print("clientDbWatchList[watchEventName]['closeWatch']",clientDbWatchList[watchEventName]['closeWatch'])
                         clientDbWatchList[watchEventName]['watch'].close()
                        # print("dbWatchThread afterclose :",watchEventName)
 
                     time.sleep(0.1)
-                #print("clientDbWatchList[watchEventName]['clientClosed']",clientDbWatchList[watchEventName]['clientClosed'])   
+                #print("clientDbWatchList[watchEventName]['clientClosed']",clientDbWatchList[watchEventName]['clientClosed'])
                 #print("dbWatchThread stream not alive :",watchEventName)
                 clientDbWatchList[watchEventName]['threadClosed']=True
                 exitThread=True
@@ -367,12 +367,12 @@ def test_message(message):
                         if len(clientPVlist[pvname1]['socketsRW'][request.sid]['pvConnectionIds'])==0:
                             leave_room(str(pvname1)+'rw')
                             clientPVlist[pvname1]['socketsRW'].pop(request.sid)
-                        
+
                         #print("after pop",clientPVlist[pvname1]['sockets'][request.sid]['pvConnectionIds'])
                 except:
                     pass
                     #print("remove_pv_connection id not in socketsRW: ",pvConnectionId, pvname1)
-                    
+
                 try:
                     #print("before pop",clientPVlist[pvname1]['sockets'][request.sid]['pvConnectionIds'])
                     if pvConnectionId in clientPVlist[pvname1]['socketsRO'][request.sid]['pvConnectionIds']:
@@ -383,7 +383,7 @@ def test_message(message):
                         #print("after pop",clientPVlist[pvname1]['sockets'][request.sid]['pvConnectionIds'])
                 except:
                     pass
-                    #print("remove_pv_connection id not in socketsRO: ",pvConnectionId, pvname1) 
+                    #print("remove_pv_connection id not in socketsRO: ",pvConnectionId, pvname1)
                 try:
                     #print("before pop",clientPVlist[pvname1]['sockets'][request.sid]['pvConnectionIds'])
                     if pvConnectionId in clientPVlist[pvname1]['sockets'][request.sid]['pvConnectionIds']:
@@ -396,7 +396,7 @@ def test_message(message):
                         #print("after pop",clientPVlist[pvname1]['sockets'][request.sid]['pvConnectionIds'])
                 except:
                     pass
-                    #print("remove_pv_connection id not in sockets: ",pvConnectionId, pvname1) 
+                    #print("remove_pv_connection id not in sockets: ",pvConnectionId, pvname1)
 
                 #print("sockets",clientPVlist[pvname1]['sockets'])
                 #print("socketsRO",clientPVlist[pvname1]['socketsRO'])
@@ -409,7 +409,7 @@ def test_message(message):
 
         else:
             print("Error pvname not in clientPVlist: ",pvname1)
-            
+
     else:
         socketio.emit('redirectToLogIn',room=request.sid,namespace='/pvServer')
 
@@ -437,32 +437,32 @@ def test_message(message):
 
 
                 if(accessControl['permissions']['read']):
-                    
+
                     pvname2=pvname1.replace("pva://","")
                     pv= PV(pvname2,connection_timeout=0.002,connection_callback= onConnectionChange)
                     pvlist={}
                     pvlist['pv']=pv
                     pvlist['isConnected']=False
                     pvlist['initialized']=False
-                  
+
                     #pvConnectionId=str(uuid.uuid1())
                     myuid=myuid+1
                     pvConnectionId=str(myuid)
                     if(accessControl['permissions']['write']):
                         join_room(str(pvname1)+'rw')
                         join_room(str(pvname1))
-                        
-                        
-                        
+
+
+
                         pvlist['sockets']={request.sid:{'pvConnectionIds':{pvConnectionId:True}}}
                         pvlist['socketsRW']={request.sid:{'pvConnectionIds':{pvConnectionId:True}}}
                         pvlist['socketsRO']={}
                     else:
                         join_room(str(pvname1)+'ro')
                         join_room(str(pvname1))
-                   
-                        
-                       
+
+
+
                         pvlist['sockets']={request.sid:{'pvConnectionIds':{pvConnectionId:True}}}
                         pvlist['socketsRO']={request.sid:{'pvConnectionIds':{pvConnectionId:True}}}
                         pvlist['socketsRW']={}
@@ -481,7 +481,7 @@ def test_message(message):
 
             if "pva://" in pvname1:
                 if(accessControl['permissions']['read']):
-                    
+
                     pvname2=pvname1.replace("pva://","")
                     clientPVlist[pvname1]['initialized']=False
                     myuid=myuid+1
@@ -494,7 +494,7 @@ def test_message(message):
                         join_room(str(pvname1)+'rw')
                         join_room(str(pvname1))
                         if request.sid in clientPVlist[pvname1]['sockets']:
-                            
+
                             if 'pvConnectionIds' in clientPVlist[pvname1]['sockets'][request.sid]:
                                 if  pvConnectionId in clientPVlist[pvname1]['sockets'][request.sid]['pvConnectionIds']:
                                     print("not a unique id ",pvConnectionId, " ",pvname1 )
@@ -517,8 +517,8 @@ def test_message(message):
                         else:
                             clientPVlist[pvname1]['socketsRW'][request.sid]={'pvConnectionIds':{pvConnectionId:True}}
 
-                       
-                
+
+
                     else:
                         join_room(str(pvname1)+'ro')
                         join_room(str(pvname1))
@@ -545,7 +545,7 @@ def test_message(message):
                                 clientPVlist[pvname1]['socketsRO'][request.sid]['pvConnectionIds']={pvConnectionId:True}
                         else:
                             clientPVlist[pvname1]['socketsRO'][request.sid]={'pvConnectionIds':{pvConnectionId:True}}
-                    
+
                     return {"pvConnectionId":pvConnectionId}
 
 
@@ -796,12 +796,12 @@ def test_message(message):
             except:
                 print("could not remove watchID")
                 pass
-          
+
 
 
         #else:
         #    print("Error watchEventName not in clientDbWatchList: ",watchEventName)
-            
+
     else:
         socketio.emit('redirectToLogIn',room=request.sid,namespace='/pvServer')
 
@@ -894,9 +894,9 @@ def databaseBroadcastRead(message):
 
                             d={'dbURL': dbURL,'write_access':write_access,'data': data}
                             socketio.emit(eventName,d,request.sid,namespace='/pvServer')
-                            
-                            
-                            
+
+
+
                             watchEventName=eventName
                             myDbWatchUid=myDbWatchUid+1
                             dbWatchId=str(myDbWatchUid)
@@ -920,12 +920,12 @@ def databaseBroadcastRead(message):
                                 dbWatch['threadStarted']=False
                                 dbWatch['closeWatch']=False
                                 dbWatch['threadClosed']=False
-                                
-                                
+
+
                                 clientDbWatchList[watchEventName]=dbWatch
                                 join_room(str(watchEventName))
                             else:
-                                
+
                                 if request.sid in clientDbWatchList[watchEventName]['sockets']:
                                     if 'dbWatchIds' in clientDbWatchList[watchEventName]['sockets'][request.sid]:
                                         if  dbWatchIds in clientDbWatchList[watchEventName]['sockets'][request.sid]['dbWatchIds']:
@@ -940,9 +940,9 @@ def databaseBroadcastRead(message):
 
                                 join_room(str(watchEventName))
                                 #print("watch already exists: ",watchEventName)
-                           
+
                             return {"dbWatchId":dbWatchId}
-                            
+
                         except:
                           #  print("could not connect to MongoDB: ",dbURL)
                             return "Ack: Could not connect to MongoDB: "+str(dbURL)
@@ -1177,7 +1177,7 @@ def test_disconnect():
     print('Client disconnected', request.sid)
     for pvname1 in	clientPVlist:
         if "pva://" in pvname1:
-          
+
             try:
                 leave_room(str(pvname1)+'rw')
                 clientPVlist[pvname1]['socketsRW'].pop(request.sid)
@@ -1193,7 +1193,7 @@ def test_disconnect():
                 clientPVlist[pvname1]['sockets'].pop(request.sid)
             except:
                 pass
-  
+
             #print("disconn sockets",clientPVlist[pvname1]['sockets'])
             #print("disconn socketsRO",clientPVlist[pvname1]['socketsRO'])
             #print("disconn socketsRW",clientPVlist[pvname1]['socketsRW'])

--- a/pvServer/pvServer.py
+++ b/pvServer/pvServer.py
@@ -134,7 +134,7 @@ def check_pv_initialized_after_disconnect():
 
                                 socketio.emit(pvname,d,room=str(pvname),namespace='/pvServer')
                             except:
-                                log.error("Unexpected error: {}", sys.exc_info()[0])
+                                log.exception("Unexpected error")
                                 raise
 
         # for watchEventName in clientDbWatchList :

--- a/pvServer/userAuthentication/authenticate.py
+++ b/pvServer/userAuthentication/authenticate.py
@@ -121,7 +121,7 @@ def checkUserRole(username):
                         roles.append(role)
                         #print("username: "+str(username) + ' role: '+ role)
     return roles
-            
+
 
 
 #print(knownUsers)
@@ -156,7 +156,7 @@ def  AuthoriseUser(JWT):
         if JWT in knownUsers:
             username=knownUsers[JWT]['username']
             roles=checkUserRole(username)
-            
+
 #            print("match")
             return {'authorised':True,'username':username,'roles':roles}
         else:


### PR DESCRIPTION
**This pull request includes the pull request #8 and #10.** This is a result of an attempt to avoid creating a huge pull request while still being able to use the changes together without additional manual merging. I would suggest to review after #8 and #10.

**Problem**
pvServer logs to console using print. As a consequence, time of the log is not captured, redirection to a file is possible only through redirecting console output, log level is controlled using comments. At the same time, Python includes a logging library which can offer these capabilities.

**Solution**
* Added a module "log" which forwards logs to the package logging and which allows controlling the logging level through environment variables. Default log level is INFO. Log output si directed to console.
* Converted relevant calls to print() which are not commented out into log.info(). If appropriate other log levels were used.

**Visible Changes**
Logs printed into console include time and log level. If this breaks existing log parsers, the solution can be modified so that logging to the console will include this info only when requested.

**Test**
Run pvServer. This test is not really adequate because it does not test all code routes. Thus, I cannot rule out we will not see new defects.