### PR TITLE
Removed requirement of mandatory PYEPICS_LIBCA

### DIFF
--- a/pvServer/pvServer.py
+++ b/pvServer/pvServer.py
@@ -73,8 +73,8 @@ try:
     pyepics_ca = epics.ca.find_libca()
 except epics.ca.ChannelAccessException as e:
     print('ERROR: {}'.format(e))
-    print('pyepics requries EPICS base libraries libca and libCOM.')
-    print('Define location of libca through the env. var. "PYEPICS_LIBCA".')
+    print('pyepics requries EPICS base libraries ca and COM.')
+    print('Define location of ca through the env. var. "PYEPICS_LIBCA".')
     print('pyepics will use it to find the COM library as well.')
     print('See pyepics installation instructions for more details.')
     exit(1)

--- a/pvServer/pvServer.py
+++ b/pvServer/pvServer.py
@@ -13,6 +13,7 @@ from flask_socketio import SocketIO, emit, join_room, leave_room, \
 
 from bson.json_util import dumps
 
+import epics
 from epics import PV
 import os
 import sys
@@ -34,7 +35,7 @@ print("React Automation Studio V2.0.1")
 print("")
 print("pvServer Environment Variables:")
 print("")
-print('PYEPICS_LIBCA: '+ str(os.environ['PYEPICS_LIBCA']))
+print('PYEPICS_LIBCA: {}'.format(os.environ.get('PYEPICS_LIBCA', None)))
 print('EPICS_BASE: '+ str(os.environ['EPICS_BASE']))
 print('EPICS_CA_ADDR_LIST: '+ str(os.environ['EPICS_CA_ADDR_LIST']))
 print('REACT_APP_PyEpicsServerBASEURL: '+ str(os.environ['REACT_APP_PyEpicsServerBASEURL']))
@@ -65,6 +66,25 @@ if (REACT_APP_DisableLogin) :
 else:
     print("Authenitcation and Authorisation is ENABLED")
 print("")
+
+
+try:
+    pyepics_com = epics.ca.find_libCom()
+    pyepics_ca = epics.ca.find_libca()
+except epics.ca.ChannelAccessException as e:
+    print('ERROR: {}'.format(e))
+    print('pyepics requries EPICS base libraries libca and libCOM.')
+    print('Define location of libca through the env. var. "PYEPICS_LIBCA".')
+    print('pyepics will use it to find the COM library as well.')
+    print('See pyepics installation instructions for more details.')
+    exit(1)
+
+print('pyepics Configuration:')
+print()
+print('libca library: {}'.format(pyepics_ca))
+print('libCOM library: {}'.format(pyepics_com))
+print()
+
 
 socketio = SocketIO(app, async_mode=async_mode)
 thread = None


### PR DESCRIPTION
**Problem**
pvServer crashes if the environmental variable `PYEPICS_LIBCA` is not defined. `PYEPICS_LIBCA` is used by pyepics. Yet, pyepics does not require it. In fact, the documentation states at (https://cars9.uchicago.edu/software/python/pyepics3/installation.html) *"... For the most commonly used operating systems and architectures, modern version of these libraries are provided, and will be installed and used with pyepics. We strongly recommend using these. ..."*. Yet, pvServer does not allow it except by setting `PYEPICS_LIBCA` to either the pyepics binaries or an invalid path.

**Solution**
* Make use of `PYEPICS_LIBCA` optional.
* Let pyepics to search for both libca and libCOM during startup in order to discover potential misconfiguration earlier then after the first attempt to access a PV. Print outcome to the console.

**Tests**
Tested on Windows 10.
1) Start pvServer with `PYEPICS_LIBCA` pointing to an existing ca.dll.
2) Start pvServer with no `PYEPICS_LIBCA` defined.
3) Start pvServer with no `PYEPICS_LIBCA` defined and no ca.dll available.
