### PR TITLE
Fix error on array container demo

### DIFF
--- a/ReactApp/src/components/CompoundComponents/ArrayContainer.js
+++ b/ReactApp/src/components/CompoundComponents/ArrayContainer.js
@@ -144,7 +144,11 @@ function ArrayContainer(props) {
     } else {
       additionalProps["index"] = index;
     }
-    if (registersLabel !== undefined && Array.isArray(registersLabel)) {
+    if (
+      registersLabel !== undefined &&
+      Array.isArray(registersLabel) &&
+      registersLabel[index]
+    ) {
       additionalProps["label"] = registersLabel[index].toString();
     }
     return (

--- a/ReactApp/src/components/Examples/EpicsDemos.js
+++ b/ReactApp/src/components/Examples/EpicsDemos.js
@@ -177,7 +177,7 @@ class EpicsDemos extends React.Component {
             <Grid item xs={12} sm={6} >
               <ArrayContainer
                 label="First 3 samples of Sine Wave Circular Buffer using ArrayContainer"
-                registersLabel={['1','2','3']}
+                registersLabel={["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]}
                 spacing={1}
                 visibleItemsCount={3}
                 maxItemsCount={10}


### PR DESCRIPTION
Hi,
I tried the demo with the arrayContainer and when scrolling on the ArrayContainer showing 3 items it crashes.

I saw that, on a previous commit, you edited this line
      additionalProps["label"] = registersLabel[index]
into 
      additionalProps["label"] = registersLabel[index].toString();

Calling the _.toString()_ method on registerLabels requires the single item not to be undefined. I added this check.

In addiction I edited the demo; this way, when you scroll the ArrayContainer, you see the correct label on each item.