### PR TITLE
Shebang does not work on Windows host consistently

### DIFF
--- a/docker/demoioc/Dockerfile
+++ b/docker/demoioc/Dockerfile
@@ -44,11 +44,8 @@ ENV PYEPICS_LIBCA=/epics/base/lib/linux-x86_64/libca.so
 ENV PATH="/epics/base/bin/linux-x86_64/:${PATH}"
 RUN echo $PATH
 
-#RUN ls /epics/base/lib/linux-x86_64/
-
 
 WORKDIR /epics/testIOC/iocBoot/ioctestIOC/
 
-CMD ./st.cmd
-#CMD ["/epics/base/bin/linux-x86_64/caget","RFPA:IPA_TUNE_MOT:display_ENG"]
+CMD ../../bin/linux-x86_64/testIOC ./st.cmd
 EXPOSE 5000 5064 5065 8001


### PR DESCRIPTION
Would it be possible to review the following change, please?

**Problem**
Running the docker image "demoioc" fails on Windows with: `/bin/sh: 1: ./st.cmd: not found`

**Analysis**
In order to prevent issues with line ends on Windows, git can convert between
`\r\n` and `\n` while retrieving source file. Unfortunately, `/bin/sh` requires `\n` in order
to process shebang properly.

**Solution**
* Reference the binary explicitly in the demoioc DockerFile.
* Remove commented sections of DockerFile. This is an attempt to cleanup what looks like remnants of earlier iterations to me. If those fragments have value today, I will revert these changes.

**Test**
* Build the docker image (using `docker build`) and run it (using `docker run`) on Windows host.
