### PR TITLE
Improved usePolling for better performance

### DIFF
--- a/ReactApp/src/components/BaseComponents/GraphXY.js
+++ b/ReactApp/src/components/BaseComponents/GraphXY.js
@@ -684,7 +684,7 @@ GraphXY.propTypes = {
   yUnits:PropTypes.string,
   /** Custom x axis units to be used*/
   xUnits:PropTypes.string,
-  /** Directive to sample the PV values, on the client side at the polling rate*/
+  /** Directive to sample the PV values on the client side at the polling rate*/
   usePolling:PropTypes.bool,
   /** Directive to scale the y-axis as a log base 10 value*/
   yScaleLog10:PropTypes.bool,

--- a/ReactApp/src/components/BaseComponents/GraphY.js
+++ b/ReactApp/src/components/BaseComponents/GraphY.js
@@ -69,7 +69,6 @@ class GraphY extends React.Component {
     state['pvs']=pvs;
     //  state['ymin']=1000000000000000000;
     //  state['ymax']=-1000000000000000000;
-    state['PollingTimerEnabled']=false;
     state['openContextMenu']= false;
     state['x0']=0;
     state['y0']=0;
@@ -84,11 +83,7 @@ class GraphY extends React.Component {
 
 
 
-
-
     this.handleInputValue= this.handleInputValue.bind(this);
-    this.handleInputValuePolled= this.handleInputValuePolled.bind(this);
-    this.handleInputValueUnpolled= this.handleInputValueUnpolled.bind(this);
     this.handleInputValueLabel= this.handleInputValueLabel.bind(this);
     this.handleMetadata= this.handleMetadata.bind(this);
     this.multipleDataConnections=this.multipleDataConnections.bind(this);
@@ -123,45 +118,7 @@ class GraphY extends React.Component {
   }
 
   handleInputValue = (inputValue,pvname,initialized,severity,timestamp)=>{
-
-    if(this.props.usePolling){
-      let pvs=this.state.pvs;
-      pvs[pvname].initialized=initialized;
-      pvs[pvname].lastValue=inputValue;
-      pvs[pvname].severity=severity;
-      this.setState({pvs:pvs});
-    }
-    else{
-      let pvs=this.state.pvs;
-      pvs[pvname].initialized=initialized;
-      this.setState({pvs:pvs});
-      this.handleInputValueUnpolled(inputValue,pvname,initialized,severity,timestamp);
-    }
-
-
-    //  console.log("value: ",inputValue);
-    //  console.log("pvname:", pvname);
-  }
-
-
-
-  handleInputValuePolled = ()=>{
-    let pv;
-    let d = new Date();
-    let timestamp=d.getTime()/1000;
-
-    for(pv in this.state.pvnames){
-
-      if(this.state.pvs[this.state.pvnames[pv]].initialized){
-
-        //    console.log(timestamp,this.state.pvnames[pv],this.state.pvs[this.state.pvnames[pv]].lastValue);
-        this.handleInputValueUnpolled(this.state.pvs[this.state.pvnames[pv]].lastValue,this.state.pvnames[pv],this.state.pvs[this.state.pvnames[pv]].initialized,this.state.pvs[this.state.pvnames[pv]].severity,timestamp)
-      }
-    }
-    //  console.log("value: ",inputValue);
-    //  console.log("pvname:", pvname);
-  }
-  handleInputValueUnpolled = (inputValue,pvname,initialized,severity,timestamp)=>{
+  
     //console.log("unpolled");
     //  console.log("test");
     //  console.log("value: ",inputValue);
@@ -347,33 +304,6 @@ handleInputValueLabel=pvname=>(inputValue)=>{
 
 
 
-componentDidMount() {
-  if (this.props.usePolling){
-    let intervalId = setInterval(this.handleInputValuePolled, this.props.pollingRate);
-    // store intervalId in the state so it can be accessed later:
-    this.setState({'intervalId': intervalId});
-  }
-}
-
-
-componentWillUnmount() {
-  if (this.props.usePolling){
-    clearInterval(this.state.intervalId);
-  }
-}
-
-
-
-
-
-
-
-
-
-
-
-
-
 multipleDataConnections = () => {
   //this.test("test1");
   //this.handleInputValue();
@@ -390,6 +320,8 @@ multipleDataConnections = () => {
           handleInputValueLabel={this.handleInputValueLabel(this.state.pvs[pv].pvname)}
           usePvLabel={this.props.usePvLabel}
           debug={this.props.debug}
+          usePolling={this.props.usePolling}
+          pollingRate={this.props.pollingRate}
         />
 
         {this.props.usePvLabel===true?this.state.pvs[pv].label+': ':""}

--- a/ReactApp/src/components/BaseComponents/GraphY.js
+++ b/ReactApp/src/components/BaseComponents/GraphY.js
@@ -124,6 +124,7 @@ class GraphY extends React.Component {
     //  console.log("value: ",inputValue);
     //  console.log("pvname:", pvname);
     let pvs=this.state.pvs;
+    pvs[pvname].initialized=initialized;
     let yDataArray=[];
     let yTimeStampArray=[];
     //let ymax=parseFloat(this.state.ymax);
@@ -269,9 +270,6 @@ class GraphY extends React.Component {
   //   console.log('ymax end',ymax)
   //   console.log('ymin end',ymin)
 
-  this.setState({pvs:pvs});//,ymax:ymax,ymin:ymin});
-
-
   //state.pvs[pvname].inputValue=inputValue;
   //pvData.pvs[pvname].initialized=initialized;
   //pvData.pvs[pvname].severity=severity;
@@ -280,6 +278,7 @@ class GraphY extends React.Component {
 
   //this.setState(pvData);
 }
+this.setState({pvs:pvs});
 }
 
 

--- a/ReactApp/src/components/SystemComponents/DataConnection.js
+++ b/ReactApp/src/components/SystemComponents/DataConnection.js
@@ -79,6 +79,7 @@ class DataConnection extends React.Component {
     useStringValue={this.props.useStringValue}
     debug={this.props.debug}
     newValueTrigger={this.props.newValueTrigger}
+    usePolling={this.props.usePolling}
     pollingRate={this.props.pollingRate}
     />
   }

--- a/ReactApp/src/components/SystemComponents/DataConnection.js
+++ b/ReactApp/src/components/SystemComponents/DataConnection.js
@@ -79,6 +79,7 @@ class DataConnection extends React.Component {
     useStringValue={this.props.useStringValue}
     debug={this.props.debug}
     newValueTrigger={this.props.newValueTrigger}
+    pollingRate={this.props.pollingRate}
     />
   }
   { (pv.includes('pva://')&&this.props.usePvLabel===true) && <DeprecatedEpicsPV

--- a/ReactApp/src/components/SystemComponents/DataConnection.js
+++ b/ReactApp/src/components/SystemComponents/DataConnection.js
@@ -66,6 +66,8 @@ class DataConnection extends React.Component {
         outputValue=  {this.props.outputValue}
         useStringValue={this.props.useStringValue}
         debug={this.props.debug}
+        usePolling={this.props.usePolling}
+        pollingRate={this.props.pollingRate}
         />
       }
     {pv.includes('pva://')&&

--- a/ReactApp/src/components/SystemComponents/DeprecatedEpicsPV.js
+++ b/ReactApp/src/components/SystemComponents/DeprecatedEpicsPV.js
@@ -191,6 +191,7 @@ class DeprecatedEpicsPV extends React.Component {
       //    console.log("this.state.pvname",this.state.pvname);
 
       socket.on(this.state.pvname,this.updatePVData);
+      socket.on("pv_conn_change", this.updatePVData);
       socket.on('connect_error',this.connectError);
       socket.on('disconnect', this.disconnect);
       socket.on('connect', this.reconnect);
@@ -229,6 +230,7 @@ class DeprecatedEpicsPV extends React.Component {
       }
       socket.removeListener('redirectToLogIn',this.handleRedirectToLogIn);
       socket.removeListener(this.state.pvname,this.updatePVData);
+      socket.removeListener("pv_conn_change", this.updatePVData);
       socket.removeListener('connect_error',this.connectError);
       socket.removeListener('disconnect', this.disconnect);
       socket.removeListener('connect', this.reconnect);

--- a/ReactApp/src/components/SystemComponents/DeprecatedEpicsPV.js
+++ b/ReactApp/src/components/SystemComponents/DeprecatedEpicsPV.js
@@ -202,7 +202,7 @@ class DeprecatedEpicsPV extends React.Component {
           );
         }, this.props.pollingRate);
       }
-      socket.on("pv_conn_change", this.updatePVData);
+      socket.on(this.state.pvname + "_conn_change", this.updatePVData);
       socket.on('connect_error',this.connectError);
       socket.on('disconnect', this.disconnect);
       socket.on('connect', this.reconnect);
@@ -244,7 +244,7 @@ class DeprecatedEpicsPV extends React.Component {
       }
       socket.removeListener('redirectToLogIn',this.handleRedirectToLogIn);
       socket.removeListener(this.state.pvname,this.updatePVData);
-      socket.removeListener("pv_conn_change", this.updatePVData);
+      socket.removeListener(this.state.pvname + "_conn_change", this.updatePVData);
       socket.removeListener('connect_error',this.connectError);
       socket.removeListener('disconnect', this.disconnect);
       socket.removeListener('connect', this.reconnect);

--- a/ReactApp/src/components/SystemComponents/DeprecatedEpicsPV.js
+++ b/ReactApp/src/components/SystemComponents/DeprecatedEpicsPV.js
@@ -194,7 +194,6 @@ class DeprecatedEpicsPV extends React.Component {
         this.props.pollingRate === undefined || this.props.pollingRate === null) {
         socket.on(this.state.pvname, this.updatePVData);
       } else {
-        console.log(this.props.pollingRate)
         this.timerId = setInterval(() => {
           socket.emit(
             "get_polled_value",

--- a/ReactApp/src/components/SystemComponents/DeprecatedEpicsPV.js
+++ b/ReactApp/src/components/SystemComponents/DeprecatedEpicsPV.js
@@ -190,12 +190,12 @@ class DeprecatedEpicsPV extends React.Component {
     //  this.handleInitialConnection();
       this.timeout=setTimeout(this.handleInitialConnection, 3000);
       //    console.log("this.state.pvname",this.state.pvname);
-      if (this.props.pollingRate === 0 || this.props.pollingRate === undefined || this.props.pollingRate === null) {
+      if (!this.props.usePolling || this.props.pollingRate === 0 || 
+        this.props.pollingRate === undefined || this.props.pollingRate === null) {
         socket.on(this.state.pvname, this.updatePVData);
       } else {
         console.log(this.props.pollingRate)
         this.timerId = setInterval(() => {
-          console.log("poll")
           socket.emit(
             "get_polled_value",
             { data: this.state.pvname, 'clientAuthorisation': jwt },

--- a/ReactApp/src/components/SystemComponents/DeprecatedLocalPV.js
+++ b/ReactApp/src/components/SystemComponents/DeprecatedLocalPV.js
@@ -65,7 +65,16 @@ class DeprecatedLocalPV extends React.Component {
           {
             initialized:false
           },
-          this.handleInputValue
+          () => {
+            if (
+              this.props.usePolling === false || 
+              this.props.pollingRate === 0 || 
+              this.props.pollingRate === undefined ||
+              this.props.pollingRate === null
+            ) {
+              this.handleInputValue();
+            }
+          }
         );
 
         if (this.props.debug===true){
@@ -76,7 +85,17 @@ class DeprecatedLocalPV extends React.Component {
         if (msg.newmetadata=='False'){
           this.setState({['internalValue']: this.props.useStringValue===true? msg.char_value:msg.value,
           severity: msg.severity},
-        this.handleInputValue);
+            () => {
+              if (
+                this.props.usePolling === false || 
+                this.props.pollingRate === 0 || 
+                this.props.pollingRate === undefined ||
+                this.props.pollingRate === null
+              ) {
+                this.handleInputValue();
+              }
+            }
+          );
           if (this.props.debug===true){
             console.log('no metadata');
           }
@@ -91,7 +110,16 @@ class DeprecatedLocalPV extends React.Component {
             ['internalValue']: this.props.useStringValue===true? msg.char_value:msg.value,
             initialized:true ,
             severity: msg.severity},
-            this.handleMetadata
+            () => {
+              if (
+                this.props.usePolling === false || 
+                this.props.pollingRate === 0 || 
+                this.props.pollingRate === undefined ||
+                this.props.pollingRate === null
+              ) {
+                this.handleMetadata();
+              }
+            }
           );
           //        if (typeof this.props.handleMetadata !== 'undefined'){
           //          this.props.handleMetadata(this.state['pv']);
@@ -150,13 +178,17 @@ class DeprecatedLocalPV extends React.Component {
 
         this.context.updateLocalVariable(this.state.pvname,msg);
         this.updatePVData(this.context.localVariables[this.state.pvname]);
+        if (this.props.usePolling === true && this.props.pollingRate > 0) {
+          this.timer = setInterval(() => this.handleMetadata(), this.props.pollingRate);
+        }
       }
       else{
-
         //this.context.localVariables[this.state.pvname].newmetadata='True';
         this.updatePVData(this.context.localVariables[this.state.pvname]);
       //  console.log(this.state)
-
+        if (this.props.usePolling === true && this.props.pollingRate > 0) {
+          this.timer = setInterval(() => this.handleMetadata(), this.props.pollingRate);
+        }
       }
 
 
@@ -169,7 +201,9 @@ class DeprecatedLocalPV extends React.Component {
   }
 
   componentWillUnmount(){
-
+    if (this.timer !== undefined) {
+     clearInterval(this.timer)
+    }
     //  socket.removeListener(this.state.pvname,this.testFunction);
 
     //    if (this.props.debug===true){

--- a/ReactApp/src/components/SystemComponents/EpicsPV.js
+++ b/ReactApp/src/components/SystemComponents/EpicsPV.js
@@ -257,7 +257,7 @@ EpicsPV.propTypes = {
   useStringValue: PropTypes.bool,
 
   /**
-   * Activate pollingRate.
+   * Directive to sample the PV values on the client side at the polling rate.
    */
    usePolling: PropTypes.bool,
 

--- a/ReactApp/src/components/SystemComponents/EpicsPV.js
+++ b/ReactApp/src/components/SystemComponents/EpicsPV.js
@@ -126,7 +126,8 @@ export const useEpicsPV = (props) => {
 
     socketRef.current.emit('request_pv_info', { data: pv.pvname, 'clientAuthorisation': jwtRef.current },handleRequestPvInfoAck);
     let timerId;
-    if (props.pollingRate === 0) {
+    if (!props.usePolling || props.pollingRate === 0 || 
+      props.pollingRate === undefined || props.pollingRate === null) {
       socketRef.current.on(pv.pvname, updatePVData);
     } else {
       timerId = setInterval(() => {
@@ -256,6 +257,11 @@ EpicsPV.propTypes = {
   useStringValue: PropTypes.bool,
 
   /**
+   * Activate pollingRate.
+   */
+   usePolling: PropTypes.bool,
+
+  /**
    * Read value from PV on specified period interval [ms].
    * If set to zero, no polling is applied.
    */
@@ -269,7 +275,8 @@ EpicsPV.propTypes = {
  */
 // static defaultProps=WrappedComponent.defaultProps;
 EpicsPV.defaultProps = {
-  pollingRate: 0,
+  pollingRate: 100,
+  usePolling: false,
   debug: false,
 
 };

--- a/ReactApp/src/components/SystemComponents/EpicsPV.js
+++ b/ReactApp/src/components/SystemComponents/EpicsPV.js
@@ -138,7 +138,7 @@ export const useEpicsPV = (props) => {
         );
       }, props.pollingRate);
     }
-    socketRef.current.on("pv_conn_change", updatePVData);
+    socketRef.current.on(pv.pvname + "_conn_change", updatePVData);
     socketRef.current.on('connect_error', connectError);
     socketRef.current.on('disconnect', disconnect);
 
@@ -149,7 +149,7 @@ export const useEpicsPV = (props) => {
         socketRef.current.emit('remove_pv_connection', { pvname: pv.pvname, pvConnectionId: pvConnectionId, 'clientAuthorisation': jwtRef.current });
       }
       socketRef.current.removeListener(pv.pvname, updatePVData);
-      socketRef.current.removeListener("pv_conn_change", updatePVData);
+      socketRef.current.removeListener(pv.pvname + "_conn_change", updatePVData);
       socketRef.current.removeListener('connect_error', connectError);
       socketRef.current.removeListener('disconnect', disconnect);
       if (timerId !== undefined) {

--- a/ReactApp/src/components/SystemComponents/EpicsPV.js
+++ b/ReactApp/src/components/SystemComponents/EpicsPV.js
@@ -137,10 +137,9 @@ export const useEpicsPV = (props) => {
         );
       }, props.pollingRate);
     }
-    socketRef.current.on("init_" + pv.pvname, updatePVData);
+    socketRef.current.on("pv_conn_change", updatePVData);
     socketRef.current.on('connect_error', connectError);
     socketRef.current.on('disconnect', disconnect);
-    socketRef.current.on('reconnect', reconnect);
 
     return () => {
 
@@ -149,10 +148,9 @@ export const useEpicsPV = (props) => {
         socketRef.current.emit('remove_pv_connection', { pvname: pv.pvname, pvConnectionId: pvConnectionId, 'clientAuthorisation': jwtRef.current });
       }
       socketRef.current.removeListener(pv.pvname, updatePVData);
-      socketRef.current.removeListener("init_"+pv.pvname, updatePVData);
+      socketRef.current.removeListener("pv_conn_change", updatePVData);
       socketRef.current.removeListener('connect_error', connectError);
       socketRef.current.removeListener('disconnect', disconnect);
-      socketRef.current.removeListener('reconnect', reconnect);
       if (timerId !== undefined) {
         clearInterval(timerId);
       }

--- a/ReactApp/src/components/SystemComponents/LocalPV.js
+++ b/ReactApp/src/components/SystemComponents/LocalPV.js
@@ -162,10 +162,34 @@ export const useLocalPV = (props) => {
  **/
 const LocalPV = (props) => {
   const pv = useLocalPV(props);
+  const [read, setRead] = useState(false);
   useEffect(() => {
-    props.pvData(pv);
+    if (
+      props.usePolling === false || 
+      props.pollingRate === 0 || 
+      props.pollingRate === undefined ||
+      props.pollingRate === null
+    ) {
+      props.pvData(pv);
+    } else if (read) {
+      props.pvData(pv);
+      setRead(false);  
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pv])
+  }, [pv, read]);
+  useEffect(() => {
+    let timer;
+    if (props.usePolling === true && props.pollingRate > 0) {
+      timer = setInterval(() => {
+        setRead(true);
+      }, props.pollingRate)
+    }
+    return () => { 
+      if (timer !== undefined) {
+        clearInterval(timer);
+      }
+    } 
+  }, []);
 
   return (
     <React.Fragment>
@@ -215,6 +239,16 @@ LocalPV.propTypes = {
    */
   useStringValue: PropTypes.bool,
 
+  /**
+   * Directive to sample the PV values on the client side at the polling rate.
+   */
+  usePolling: PropTypes.bool,
+
+  /**
+   * Read value from PV on specified period interval [ms].
+   * If set to zero, no polling is applied.
+   */
+  pollingRate: PropTypes.number,
 
 };
 
@@ -224,7 +258,8 @@ LocalPV.propTypes = {
  */
 // static defaultProps=WrappedComponent.defaultProps;
 LocalPV.defaultProps = {
-
+  pollingRate: 100,
+  usePolling: false,
   debug: false,
   
 };

--- a/ReactApp/src/components/SystemComponents/PV.js
+++ b/ReactApp/src/components/SystemComponents/PV.js
@@ -327,7 +327,7 @@ PV.propTypes = {
   useStringValue: PropTypes.bool,
 
   /**
-   * Activate pollingRate.
+   * Directive to sample the PV values on the client side at the polling rate.
    */
    usePolling: PropTypes.bool,
 

--- a/ReactApp/src/components/SystemComponents/PV.js
+++ b/ReactApp/src/components/SystemComponents/PV.js
@@ -63,6 +63,7 @@ const PV = (props) => {
     outputValue: props.outputValue,
     useStringValue: props.useStringValue,
     initialLocalVariableValue: props.initialLocalVariableValue,
+    usePolling: props.usePolling,
     pollingRate: props.pollingRate,
     debug: props.debug,
     pvData: pvData('data')
@@ -326,6 +327,11 @@ PV.propTypes = {
   useStringValue: PropTypes.bool,
 
   /**
+   * Activate pollingRate.
+   */
+   usePolling: PropTypes.bool,
+
+  /**
    * Read value from PV on specified period interval [ms].
    * If set to zero, no polling is applied.
    */
@@ -340,7 +346,8 @@ PV.propTypes = {
  */
 // static defaultProps=WrappedComponent.defaultProps;
 PV.defaultProps = {
-  pollingRate: 0,
+  usePolling: false,
+  pollingRate: 100,
   debug: false,
   useMetadata: true,
 

--- a/ReactApp/src/components/SystemComponents/Widgets/Widget.js
+++ b/ReactApp/src/components/SystemComponents/Widgets/Widget.js
@@ -568,7 +568,7 @@ Widget.propTypes = {
   tooltipProps:PropTypes.object,
 
   /**
-   * Activate pollingRate.
+   * Directive to sample the PV values on the client side at the polling rate.
    */
    usePolling: PropTypes.bool,
 

--- a/ReactApp/src/components/SystemComponents/Widgets/Widget.js
+++ b/ReactApp/src/components/SystemComponents/Widgets/Widget.js
@@ -274,6 +274,7 @@ import {
             outputValue={outputValue}
             useStringValue={props.useStringValue}
             initialLocalVariableValue={props.initialLocalVariableValue}
+            usePolling={props.usePolling}
             pollingRate={props.pollingRate}
             debug={props.debug}
             pvData={(data) => setState(prevState => {
@@ -318,6 +319,7 @@ import {
     outputValue={outputValue}
     useStringValue={props.useStringValue}
     initialLocalVariableValue={props.initialLocalVariableValue}
+    usePolling={props.usePolling}
     pollingRate={props.pollingRate}
     debug={props.debug}
     pvData={setPv}
@@ -566,6 +568,11 @@ Widget.propTypes = {
   tooltipProps:PropTypes.object,
 
   /**
+   * Activate pollingRate.
+   */
+   usePolling: PropTypes.bool,
+
+  /**
    * Read value from PV on specified period interval [ms].
    * If set to zero, no polling is applied.
    */
@@ -586,7 +593,8 @@ Widget.defaultProps = {
   useMetadata: true,
   tooltip:"",
   writeOutputValueToAllpvs:false,
-  pollingRate: 0,
+  usePolling: false,
+  pollingRate: 100,
 };
 
 export default Widget

--- a/pvServer/pvServer.py
+++ b/pvServer/pvServer.py
@@ -309,10 +309,10 @@ def check_pv_initialized_after_disconnect():
                                 d['chid']=str(d['chid'])
                                 try:
                                     rw_room=str(pvname)+'rw'
-                                    socketio.emit("pv_conn_change",d,room=rw_room,namespace='/pvServer')
+                                    socketio.emit(pvname + "_conn_change",d,room=rw_room,namespace='/pvServer')
                                     d['write_access']=False
                                     ro_room=str(pvname)+'ro'
-                                    socketio.emit("pv_conn_change",d,room=ro_room,namespace='/pvServer')
+                                    socketio.emit(pvname + "_conn_change",d,room=ro_room,namespace='/pvServer')
                                     clientPVlist[pvname]['isConnected']=True
                                     clientPVlist[pvname]['initialized']=True
                                 #
@@ -332,7 +332,7 @@ def check_pv_initialized_after_disconnect():
                                     d['pvname']= pvname
                                     d['connected']= '0'
 
-                                    socketio.emit("pv_conn_change",d,room=str(pvname),namespace='/pvServer')
+                                    socketio.emit(pvname + "_conn_change",d,room=str(pvname),namespace='/pvServer')
                                 except:
                                     log.exception("Unexpected error")
                                     raise
@@ -502,7 +502,7 @@ def onConnectionChange(pvname=None, conn= None, value=None, **kws):
             clientPVlist[pvname1]['initialized']=False
             if 'last_event' in clientPVlist[pvname1]:
                 del clientPVlist[pvname1]['last_event']
-            socketio.emit("pv_conn_change",d,room=str(pvname1),namespace='/pvServer')
+            socketio.emit(pvname1 + "_conn_change",d,room=str(pvname1),namespace='/pvServer')
         except:
             error=2
 

--- a/pvServer/pvServer.py
+++ b/pvServer/pvServer.py
@@ -309,10 +309,10 @@ def check_pv_initialized_after_disconnect():
                                 d['chid']=str(d['chid'])
                                 try:
                                     rw_room=str(pvname)+'rw'
-                                    socketio.emit("init_"+pvname,d,room=rw_room,namespace='/pvServer')
+                                    socketio.emit("pv_conn_change",d,room=rw_room,namespace='/pvServer')
                                     d['write_access']=False
                                     ro_room=str(pvname)+'ro'
-                                    socketio.emit("init_"+pvname,d,room=ro_room,namespace='/pvServer')
+                                    socketio.emit("pv_conn_change",d,room=ro_room,namespace='/pvServer')
                                     clientPVlist[pvname]['isConnected']=True
                                     clientPVlist[pvname]['initialized']=True
                                 #
@@ -332,7 +332,7 @@ def check_pv_initialized_after_disconnect():
                                     d['pvname']= pvname
                                     d['connected']= '0'
 
-                                    socketio.emit("init_"+pvname,d,room=str(pvname),namespace='/pvServer')
+                                    socketio.emit("pv_conn_change",d,room=str(pvname),namespace='/pvServer')
                                 except:
                                     log.exception("Unexpected error")
                                     raise
@@ -502,7 +502,7 @@ def onConnectionChange(pvname=None, conn= None, value=None, **kws):
             clientPVlist[pvname1]['initialized']=False
             if 'last_event' in clientPVlist[pvname1]:
                 del clientPVlist[pvname1]['last_event']
-            socketio.emit("init_"+pvname1,d,room=str(pvname1),namespace='/pvServer')
+            socketio.emit("pv_conn_change",d,room=str(pvname1),namespace='/pvServer')
         except:
             error=2
 


### PR DESCRIPTION
So, this happened:

We developed a RAS-based GUI as an upgrade to an older one based on CS-studio. The two interfaces are really similar, as you can see:

**CSS**:
![Screenshot from 2021-04-09 14-08-53](https://user-images.githubusercontent.com/26935676/114185277-daf1b980-9945-11eb-9ca8-f7fd152f4ae6.png)
**RAS**:
![Screenshot from 2021-04-09 14-02-57](https://user-images.githubusercontent.com/26935676/114185337-ea710280-9945-11eb-9485-77881d39421c.png)

So we decided to let some users try the new interface to control their power supplies. After a few days they came back and told us that they were unable to use the new interface because it was too slow and they experienced periodic disconnections and artifacts in the graphs, which were not present in CS-Studio. They said they prefer to use CS-Studio, because it's more reliable (SIGH!).

@giosava94 and me started to investigate the problem. The graphs in the page are connected to 7 PVs for each power supply, for a total of 21 PVs for the three power supplies in the page. Each PV changes with a period of 0.1s. This means about 210 updates to the page per second. This is a high refresh rate, but CSS can easily handle this by sampling the PVs with a 500ms period. So, we had decided to use the same polling rate of 500ms in RAS.

_**BUT**_

turns out this was still far too slow and RAS could not keep up with the updates on a (not-so-performant) desktop PC. Why? Because all the updates were still propagated from the backend to the frontend up to ``GraphY`` (or ``GraphXY``) which was responsible to implement the polling. This is very inefficient and resulted in the crash of the interface, as if the PV disconnected.

What we did to solve the performance issue:

1. When using polling the frontend does not listen to the sockeIO messages with all the change events of the PV, but periodically query the backend to get the last value, thus reducing the number of events received by the frontend and subsequent renderizations. A new socketIO message called ``get_polled_value`` was defined for this purpose.
2. The backend is responsible to cache the last value of all connected PVs. It listens on ``get_polled_value`` and answer with the last value received for the polled PV.
3. A new message called ``pvname + "_conn_change"`` was defined to send messages which must be received even when using ``usePolling``, since in that case the frontend is not listening to the updates messages. In fact, we want that the connection/disconnection events are received directly, without waiting for the polling.
4. We implemented this feature in ``EpicsPV`` and ``DeprecatedEpicsPV``, so now ``usePolling`` is effective in every widget and also on the old graphs.
5. ``GraphY`` and ``GrapXY`` were updated with the new polling mechanism. This means they are now simpler and thus easier to update.
6. To maintain 100% backward compatibility ``usePolling`` was implemented also on ``LocalPV`` and ``DeprecatedLocalPV`` on the frontend.

This resulted in much improved performance. We run some tests, these are the results:


**BEFORE:**
![before2](https://user-images.githubusercontent.com/26935676/114191085-522a4c00-994c-11eb-9f52-c7044a251c58.gif)

**AFTER:**
![after2](https://user-images.githubusercontent.com/26935676/114191140-6110fe80-994c-11eb-8922-4694489a93cf.gif)

As you can see, before the update the page with a lot of graphs could not keep up with the updates of the PVs and after a while it crashes. After the update the page has much better performance.
